### PR TITLE
modify fetch messages API to retrieve only new messages

### DIFF
--- a/backend/src/db/mock/messageMock.ts
+++ b/backend/src/db/mock/messageMock.ts
@@ -96,8 +96,24 @@ const updateMessagesMock = (props: MessageProps): { status: string } => {
   };
 };
 
-const fetchMessagesMock = (chatId: string): MessageObject => {
-  return messagesMock.find((obj) => obj.chatId === chatId);
+const fetchMessagesMock = (
+  chatId: string,
+  latestTimestamp: number | undefined,
+): MessageObject => {
+  const messageObj = messagesMock.find((obj) => obj.chatId === chatId);
+  if (!latestTimestamp) {
+    return messageObj;
+  }
+  let messages = [];
+  let i = messageObj.messages.length - 1;
+  while (i >= 0 && messageObj.messages[i].timestamp > latestTimestamp) {
+    messages = [...messages, messageObj.messages[i]];
+    i -= 1;
+  }
+  return {
+    chatId,
+    messages,
+  };
 };
 
 const connectToChat = (

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,8 +2,10 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
+  const PORT = process.env.BACKEND_PORT || 4200;
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  await app.listen(4200);
+  await app.listen(PORT);
+  console.log(`App started successfully and listening on post ${PORT}`);
 }
 bootstrap();

--- a/backend/src/message/message.service.ts
+++ b/backend/src/message/message.service.ts
@@ -25,9 +25,9 @@ export class MessageService {
   }
 
   fetchMessages(req: Request, res: Response): void {
-    const { chatId } = req.body;
+    const { chatId, latestTimestamp } = req.body;
     if (chatId) {
-      const messageObj = fetchMessagesMock(chatId);
+      const messageObj = fetchMessagesMock(chatId, latestTimestamp);
       if (messageObj) {
         console.log('Message fetched successfully!');
         res.json({ messages: messageObj.messages });


### PR DESCRIPTION
https://github.com/Substancia/REACTive-cucumber-NEST/issues/3

- added support for optional `latestTimestamp` field in POST `/message/fetch` to retrieve only messages with later timestamp