### PR TITLE
Feature/create automated start script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatapp-backend",
+  "name": "cucumber-backend",
   "version": "0.0.1",
   "description": "",
   "author": "",

--- a/cucumber.sh
+++ b/cucumber.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. ./scripts/startServers.sh
+
+echo "Invalid command: $1"
+echo "$script for usage."
+exit 1

--- a/cucumber.sh
+++ b/cucumber.sh
@@ -2,6 +2,7 @@
 
 . ./scripts/startServers.sh
 
+. ./scripts/stopServers.sh
+
 echo "Invalid command: $1"
-echo "$script for usage."
 exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,10 @@ services:
     volumes:
       - data-vol:/data/db
     environment:
-      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
-      - MYSQL_DATABASE=${DB_DATABASE}
-      - MYSQL_HOST=${DB_HOST}
-      - MYSQL_USERNAME=${DB_USERNAME}
+      - MONGO_ROOT_PASSWORD=${DB_PASSWORD}
+      - MONGO_DATABASE=${DB_DATABASE}
+      - MONGO_HOST=${DB_HOST}
+      - MONGO_USERNAME=${DB_USERNAME}
     networks:
       - cucumber
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Base docker-compose file
+version: "1"
+
+networks:
+  cucumber: {}
+
+services:
+  cucumber-backend:
+    hostname: cucumber-backend
+    container_name: cucumber-backend
+    build:
+      context: ./backend
+    volumes:
+      - ./backend:/usr/src/app
+      - /usr/src/app/node_modules
+    command: "yarn start"
+    environment:
+      NODE_ENV: development
+      SERVICE_NAME: cucumber-backend
+    ports:
+      - 4200:4200
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "cucumber-backend", "service": "cucumber-backend"}]'
+
+  cucumber-frontend:
+    hostname: cucumber-frontend
+    container_name: cucumber-frontend
+    build:
+      context: ./frontend
+    volumes:
+      - ./frontend:/usr/src/app
+      - /usr/src/app/node_modules
+    command: "yarn start"
+    environment:
+      NODE_ENV: development
+      SERVICE_NAME: cucumber-frontend
+    ports:
+      - 4200:4200
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "cucumber-frontend", "service": "cucumber-frontend"}]'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - ./backend:/usr/src/app
       - /usr/src/app/node_modules
+    networks:
+      - cucumber
     command: "yarn start"
     environment:
       NODE_ENV: development
@@ -30,6 +32,8 @@ services:
     volumes:
       - ./frontend:/usr/src/app
       - /usr/src/app/node_modules
+    networks:
+      - cucumber
     command: "yarn start"
     environment:
       NODE_ENV: development
@@ -38,3 +42,21 @@ services:
       - 4200:4200
     labels:
       com.datadoghq.ad.logs: '[{"source": "cucumber-frontend", "service": "cucumber-frontend"}]'
+
+  cucumber-database:
+    hostname: cucumber-database
+    container_name: cucumber-database
+    build:
+      context: ./database
+    ports:
+      - 27017:27017
+    volumes:
+      - data-vol:/data/db
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_DATABASE}
+      - MYSQL_HOST=${DB_HOST}
+      - MYSQL_USERNAME=${DB_USERNAME}
+    networks:
+      - cucumber
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Base docker-compose file
-version: "1"
+version: "3"
 
 networks:
   cucumber: {}
@@ -21,8 +21,6 @@ services:
       SERVICE_NAME: cucumber-backend
     ports:
       - 4200:4200
-    labels:
-      com.datadoghq.ad.logs: '[{"source": "cucumber-backend", "service": "cucumber-backend"}]'
 
   cucumber-frontend:
     hostname: cucumber-frontend
@@ -39,24 +37,22 @@ services:
       NODE_ENV: development
       SERVICE_NAME: cucumber-frontend
     ports:
-      - 4200:4200
-    labels:
-      com.datadoghq.ad.logs: '[{"source": "cucumber-frontend", "service": "cucumber-frontend"}]'
+      - 3000:3000
 
-  cucumber-database:
-    hostname: cucumber-database
-    container_name: cucumber-database
-    build:
-      context: ./database
-    ports:
-      - 27017:27017
-    volumes:
-      - data-vol:/data/db
-    environment:
-      - MONGO_ROOT_PASSWORD=${DB_PASSWORD}
-      - MONGO_DATABASE=${DB_DATABASE}
-      - MONGO_HOST=${DB_HOST}
-      - MONGO_USERNAME=${DB_USERNAME}
-    networks:
-      - cucumber
-    restart: always
+  # cucumber-database:
+  #   hostname: cucumber-database
+  #   container_name: cucumber-database
+  #   build:
+  #     context: ./database
+  #   ports:
+  #     - 27017:27017
+  #   volumes:
+  #     - data-vol:/data/db
+  #   environment:
+  #     - MONGO_ROOT_PASSWORD=${DB_PASSWORD}
+  #     - MONGO_DATABASE=${DB_DATABASE}
+  #     - MONGO_HOST=${DB_HOST}
+  #     - MONGO_USERNAME=${DB_USERNAME}
+  #   networks:
+  #     - cucumber
+  #   restart: always

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,4 +15,4 @@ RUN yarn install && yarn build
 CMD [ "yarn", "start" ]
 
 HEALTHCHECK --start-period=180s --interval=60s  \
-    CMD curl -f http://localhost:4200/healthcheck || exit 1
+    CMD curl -f http://localhost:3000/healthcheck || exit 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "cucumber-frontend",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+    "license": "UNLICENSED",
+    "devDependencies": {
+        "pm2": "^5.2.2"
+    }
+}

--- a/scripts/startServers.sh
+++ b/scripts/startServers.sh
@@ -1,9 +1,26 @@
+startServersLocal() {
+    BASE_PATH=$PWD
+    cd ./backend
+    yarn
+    $BASE_PATH/node_modules/pm2/bin/pm2 start yarn --interpreter bash --name cucumber-backend -- start
+    cd $BASE_PATH
+    cd ./frontend
+    yarn
+    $BASE_PATH/node_modules/pm2/bin/pm2 start yarn --interpreter bash --name cucumber-frontend -- start
+    cd $BASE_PATH
+}
+
 startServersDocker() {
     docker-compose -f docker-compose.yml
 }
 
-if [ "$1" == "start:docker" ]
-then
-	startServersDocker
-	exit
-fi
+case "$1" in
+    "start:local")
+        startServersLocal
+        exit
+        ;;
+    "start:docker")
+        startServersDocker
+        exit
+        ;;
+esac

--- a/scripts/startServers.sh
+++ b/scripts/startServers.sh
@@ -1,0 +1,9 @@
+startServersDocker() {
+    docker-compose -f docker-compose.yml
+}
+
+if [ "$1" == "start:docker" ]
+then
+	startDevAnt $2
+	exit
+fi

--- a/scripts/startServers.sh
+++ b/scripts/startServers.sh
@@ -11,7 +11,9 @@ startServersLocal() {
 }
 
 startServersDocker() {
-    docker-compose -f docker-compose.yml
+	docker-compose \
+    -f docker-compose.yml \
+    up -d  --renew-anon-volumes  --no-build
 }
 
 case "$1" in

--- a/scripts/startServers.sh
+++ b/scripts/startServers.sh
@@ -4,6 +4,6 @@ startServersDocker() {
 
 if [ "$1" == "start:docker" ]
 then
-	startDevAnt $2
+	startServersDocker
 	exit
 fi

--- a/scripts/stopServers.sh
+++ b/scripts/stopServers.sh
@@ -8,10 +8,8 @@ stopServersDocker(){
 	docker-compose -f docker-compose.yml rm -svf
 }
 
-echo HERE
 case "$1" in
     "stop:local")
-        echo NOW HERE
         stopServersLocal
         exit
         ;;

--- a/scripts/stopServers.sh
+++ b/scripts/stopServers.sh
@@ -1,0 +1,22 @@
+stopServersLocal() {
+    BASE_PATH=$PWD
+    $BASE_PATH/node_modules/pm2/bin/pm2 delete cucumber-backend
+    $BASE_PATH/node_modules/pm2/bin/pm2 delete cucumber-frontend
+}
+
+stopServersDocker(){
+	docker-compose -f docker-compose.yml rm -svf
+}
+
+echo HERE
+case "$1" in
+    "stop:local")
+        echo NOW HERE
+        stopServersLocal
+        exit
+        ;;
+    "stop:docker")
+        stopServersDocker
+        exit
+        ;;
+esac


### PR DESCRIPTION
- created a start script to start all servers together
- created a stop script to stop all servers together
- currently this is done only as node servers (using pm2), need to extend to docker-compose

To test:-
- run `yarn` in repo directory
- run `chmod +x cucumber.sh` to make the script executable
- run `./cucumber.sh start:local` to start all servers
- run `./cucumber.sh stop:local` to stop all servers
- run `./cucumber.sh start:docker` to start all servers on docker
- run `./cucumber.sh stop:docker` to stop all servers on docker